### PR TITLE
fix(a2sb): pass cos/sin channels in correct order to griffinlim phase…

### DIFF
--- a/A2SB/audio_transforms/transforms.py
+++ b/A2SB/audio_transforms/transforms.py
@@ -242,8 +242,8 @@ class MagInstPhaseToGriffinLim(nn.Module):
         window = self.window.to(mag_inst_phase.device)
         result = griffinlim(
             mag_inst_phase[0], 
-            mag_inst_phase[2],
             mag_inst_phase[1],
+            mag_inst_phase[2],
             window=window,
             n_fft=self.n_fft,
             win_length=self.win_length,

--- a/tests/test_griffinlim_phase_order.py
+++ b/tests/test_griffinlim_phase_order.py
@@ -1,0 +1,80 @@
+"""Regression test: MagInstPhaseToGriffinLim must pass the instantaneous-phase
+channels to griffinlim() in the documented order.
+
+The channel layout produced by ComplexToMagInstPhase (and consumed everywhere
+else) is [mag, cos(theta), sin(theta)]. griffinlim()'s signature is
+griffinlim(specgram, init_phase_cos, init_phase_sin, ...). The bug passed
+channel 2 (sin) as init_phase_cos and channel 1 (cos) as init_phase_sin,
+rotating the initial phase estimate by 90 degrees whenever phase-initialized
+Griffin-Lim is used (rand_init=False).
+
+The module hardcodes rand_init=True today, so this test spies on the
+griffinlim() call and asserts on the argument values directly.
+"""
+
+import sys
+import types
+from unittest import mock
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+
+def _stub_module(name, **attrs):
+    mod = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(mod, key, value)
+    sys.modules[name] = mod
+    return mod
+
+
+# torchaudio and jsonargparse are not required for this transform; stub them
+# so the module imports without the heavy/optional dependencies.
+class _Identity:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __call__(self, x, *args, **kwargs):
+        return x
+
+
+_stub_module("torchaudio")
+_stub_module(
+    "torchaudio.transforms",
+    Spectrogram=_Identity,
+    InverseSpectrogram=_Identity,
+)
+_stub_module("jsonargparse", Namespace=dict)
+
+from A2SB.audio_transforms import transforms  # noqa: E402
+
+
+def test_mag_inst_phase_channels_passed_in_order():
+    n_fft = 8
+    transform = transforms.MagInstPhaseToGriffinLim(
+        n_fft=n_fft, win_length=n_fft, hop_length=2
+    )
+
+    mag = torch.full((n_fft // 2 + 1, 3), 0.5)
+    cos = torch.full((n_fft // 2 + 1, 3), 0.6)
+    sin = torch.full((n_fft // 2 + 1, 3), 0.8)
+    mag_inst_phase = torch.stack([mag, cos, sin])
+
+    with mock.patch.object(transforms, "griffinlim") as spy:
+        spy.return_value = torch.zeros(1)
+        transform.forward(mag_inst_phase)
+
+    assert spy.call_count == 1
+    args, _kwargs = spy.call_args
+    specgram, init_phase_cos, init_phase_sin = args[0], args[1], args[2]
+
+    assert torch.equal(specgram, mag), "specgram must be the magnitude channel"
+    assert torch.equal(init_phase_cos, cos), (
+        "init_phase_cos must receive channel 1 (cos); "
+        "got the sin channel (cos/sin swapped)"
+    )
+    assert torch.equal(init_phase_sin, sin), (
+        "init_phase_sin must receive channel 2 (sin); "
+        "got the cos channel (cos/sin swapped)"
+    )


### PR DESCRIPTION
… init

## Summary

`MagInstPhaseToGriffinLim.forward` passed the instantaneous-phase channels to `griffinlim()` in swapped order: the sine channel was passed as `init_phase_cos` and the cosine channel as `init_phase_sin`. When phase-initialized Griffin-Lim is used (`rand_init=False`), the reconstruction starts from a phase rotated by 90° (cos/sin exchanged), corrupting the initial phase estimate.

The module currently hardcodes `rand_init=True`, so the swapped arguments are ignored today and there is **no behavior change**; this fixes the latent wiring bug so enabling phase initialization does the right thing.

## Root cause

In `A2SB/audio_transforms/transforms.py`, the channel layout produced by `ComplexToMagInstPhase` (and consumed everywhere else) is `[mag, cos(theta), sin(theta)]`:

```python
return torch.cat([mag, torch.cos(phase), torch.sin(phase)], 0)
```

`griffinlim()`'s signature is:

```python
def griffinlim(specgram, init_phase_cos, init_phase_sin, ...)
# used as: torch.complex(init_phase_cos, init_phase_sin)
```

But the call site was:

```python
result = griffinlim(
    mag_inst_phase[0],   # specgram = mag          (correct)
    mag_inst_phase[2],   # init_phase_cos <- sin!  (wrong)
    mag_inst_phase[1],   # init_phase_sin <- cos!  (wrong)
    ...
)
```

## Fix

Swap the two channel indices so channel 1 (cos) feeds `init_phase_cos` and channel 2 (sin) feeds `init_phase_sin`:

```python
result = griffinlim(
    mag_inst_phase[0],
    mag_inst_phase[1],
    mag_inst_phase[2],
    ...
)
```

## Testing

Repo has no test suite. Verified with a spy-based check using the system torch (2.13.0+cu130); `torchaudio`/`jsonargparse` were stubbed since they are not installed:

- Build a `[mag, cos, sin]` tensor with distinct constant channels, call `MagInstPhaseToGriffinLim.forward`, and intercept the `griffinlim()` call.
- Unmodified code: **fails** — `init_phase_cos` receives the sine channel values (0.8 instead of 0.6).
- Fixed code: **passes** — `init_phase_cos`/`init_phase_sin` receive the cos/sin channels respectively, and `specgram` receives magnitude.

## Why existing tests missed it

The repo has no automated tests for A2SB, and the only caller passes `rand_init=True`, which makes `griffinlim()` ignore the phase-init arguments entirely, so the swap is silent.